### PR TITLE
Silence warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,9 @@ option(ENABLE_PULSE "Set to ON to enable pulse audio (versus alsa)" OFF)
 option(ENABLE_TTS "Set to ON to enable text to speech" OFF)
 option(USE_SYSTEM_PUGIXML "Set to ON to use system-wide pugixml library" OFF)
 
-add_definitions(-w)
-
 # Win32 default platform & directory detection
 if(WIN32)
+	add_definitions(-w)
 
 	if (NOT CMAKE_GENERATOR_PLATFORM)
 		set(CMAKE_GENERATOR_PLATFORM Win32)	    

--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -711,7 +711,7 @@ std::vector<std::string> ApiSystem::getAvailableAudioOutputDevices()
 
 std::vector<std::string> ApiSystem::getAvailableGovernors()
 {
-	return executeEnumerationScript("/usr/bin/sh -lc \"echo \\\"default\\\"; tr \\\" \\\" \\\"\\n\\\" < /sys/devices/system/cpu/cpufreq/policy0/scaling_available_governors\" | grep \[a-z\]");
+	return executeEnumerationScript("/usr/bin/sh -lc \"echo \\\"default\\\"; tr \\\" \\\" \\\"\\n\\\" < /sys/devices/system/cpu/cpufreq/policy0/scaling_available_governors\" | grep \\[a-z\\]");
 }
 
 std::vector<std::string> ApiSystem::getAvailableColors()


### PR DESCRIPTION
- Modify ignore ES compilation warnings only on WIN32.

- Resolved the following warnings  
```
es-app/src/ApiSystem.cpp:714:41: warning: unknown escape sequence: '\]'
```