### PR TITLE
Skip 'windows' folder to improve startup performance

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -327,6 +327,10 @@ void SystemData::populateFolder(FolderData* folder, std::unordered_map<std::stri
 			if (fileInfo.path.rfind("ports") != std::string::npos)
 				continue;
 
+			// Skip windows folder for the same reason as ports folder
+			if (fileInfo.path.rfind("windows") != std:string:npos)
+				continue;
+
 			FolderData* newFolder = new FolderData(filePath, this);
 			populateFolder(newFolder, fileMap);
 


### PR DESCRIPTION
Skip scanning the Windows folder at startup--treat it similar to the Ports folder. Reduces boot time when a lot of Windows games are present. Thanks @reddestdream for the suggestion.