### PR TITLE
fake suspend - add core parking toggle

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2017,6 +2017,17 @@ void GuiMenu::openSystemSettings()
 	{
 	    SystemConf::getInstance()->set("system.shutdown_delay_running_game", std::to_string((int)(round(ctlShutdownInGameDelay->getValue()) * 60)));
 	});
+
+	// Add option to park cores on suspend
+	auto park_cores_toggle = std::make_shared<SwitchComponent>(mWindow);
+	bool internalmoduleEnabled = SystemConf::getInstance()->get("system.suspend.park_cores") == "1";
+	park_cores_toggle->setState(internalmoduleEnabled);
+	s->addWithLabel(_("ENABLE CORE PARKING"), park_cores_toggle);
+	park_cores_toggle->setOnChangedCallback([park_cores_toggle] {
+		bool park_cores_state = park_cores_toggle->getState();
+		SystemConf::getInstance()->set("system.suspend.park_cores", park_cores_state ? "1" : "0");
+	});
+	
 #endif
 
 #ifdef BATOCERA


### PR DESCRIPTION
Core parking during in-game fake suspend can cause issues with process affinity. The affinity set when the game was launched is lost when cores are brought offline and not able to be reinstated when cores are brought back online on resume.

Only an issue if the game was being pinned specifically to big / little cores, so defaulting the feature to 'enabled' but providing an opt out toggle.