### PR TITLE
GPU governor - preselect 'default'

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1993,7 +1993,7 @@ void GuiMenu::openSystemSettings()
 	std::string selectedGpuGovernor = SystemConf::getInstance()->get("system.gpuperf");
 	
 	if (selectedGpuGovernor.empty())
-		selectedGpuGovernor = "ondemand";
+		selectedGpuGovernor = "default";
 	
 	bool selectedGpuGovernorFound = false;
 	
@@ -2005,7 +2005,7 @@ void GuiMenu::openSystemSettings()
 	}
 	
 	if (!selectedGpuGovernorFound)
-		optionsGpuGovernors->add(selectedGpuGovernor, selectedGpuGovernor, true);
+		optionsGpuGovernors->selectFirstItem(); // Preselect 'default' 
 
 	s->addWithLabel(_("DEFAULT GPU SCALING GOVERNOR"), optionsGpuGovernors);
 	s->addSaveFunc([selectedGpuGovernor, optionsGpuGovernors]
@@ -2940,9 +2940,10 @@ void GuiMenu::openSystemOptionsConfiguration(Window* mWindow, std::string config
 		if (selectedGpuGovernor == (*it))
 			selectedGpuGovernorFound = true;
 	}
-	if (!selectedGpuGovernorFound)
-		optionsGpuGovernors->add(selectedGpuGovernor, selectedGpuGovernor, true);
 
+	if (!selectedGpuGovernorFound)
+		optionsGpuGovernors->selectFirstItem(); // Preselect 'default' 
+	
 	guiSystemOptions->addWithLabel(_("GPU SCALING GOVERNOR"), optionsGpuGovernors);
 	guiSystemOptions->addSaveFunc([configName, selectedGpuGovernor, optionsGpuGovernors]
 	{


### PR DESCRIPTION
Select 'default' in cases where:
- no governor has been set in system config
- an invalid governor value has been set in system config