### PR TITLE
Add RK3576 platform and enable big.LITTLE/Suspend options

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2055,7 +2055,7 @@ void GuiMenu::openSystemSettings()
 		dtbOverlayItem(mWindow, s, "custom");
 	}
 
-#if defined(AMD64) || defined(RK3326) || defined(RK3566) || defined(RK3588) || defined(RK3399) || defined(SM8250)
+#if defined(AMD64) || defined(RK3326) || defined(RK3566) || defined(RK3576) || defined(RK3588) || defined(RK3399) || defined(SM8250)
 	// Allow user control over how the device sleeps - only show for devices with real suspend enabled
 	s->addGroup(_("SUSPEND"));
 	auto optionsSleep = std::make_shared<OptionListComponent<std::string> >(mWindow, _("DEVICE SUSPEND MODE"), false);
@@ -2824,7 +2824,7 @@ void GuiMenu::openSystemOptionsConfiguration(Window* mWindow, std::string config
 	GuiSettings* guiSystemOptions = new GuiSettings(mWindow, _("SYSTEM OPTIONS").c_str());
 	bool cfound = false;
 
-#if defined(S922X) || defined(RK3588) || defined(RK3399) || defined(SM8250) || defined(SM8550)
+#if defined(S922X) || defined(RK3588) || defined(RK3576) || defined(RK3399) || defined(SM8250) || defined(SM8550)
 	// Core chooser
 	auto cores_used = std::make_shared<OptionListComponent<std::string>>(mWindow, _("CORES USED"));
 	cores_used->addRange({ {("DEFAULT"), "" }, { _("ALL"), "all" },{ _("BIG") , "big" },{ _("LITTLE") , "little" } }, SystemConf::getInstance()->get(configName + ".cores"));

--- a/es-core/src/utils/Platform.cpp
+++ b/es-core/src/utils/Platform.cpp
@@ -647,6 +647,10 @@ namespace Utils
 			return "rk3566";
 #endif
 
+#if RK3576
+			return "rk3576";
+#endif
+
 #if RK3568
 			return "rk3568";
 #endif


### PR DESCRIPTION
Adds RK3576 as a platform and enables the menus to show supported options for Suspend and big.LITTLE core parking.
Tested from a local ROCKNIX build on RG Vita Pro.