### PR TITLE
Persist Tailscale VPN state to config

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5482,6 +5482,7 @@ void GuiMenu::openNetworkSettings(bool selectWifiEnable, bool selectAdhocEnable)
 			Utils::Platform::runSystemCommand("tailscale down", "", nullptr);
 			Utils::Platform::runSystemCommand("systemctl stop tailscaled", "", nullptr);
 		}
+		SystemConf::getInstance()->set("tailscale.up", tsEnabled ? "1" : "0");
 	});
 
 


### PR DESCRIPTION
Currently, the Tailscale VPN option is broken in the GUI. If the user enables Tailscale VPN, and then exit the settings, when they go back into the Network settings, Tailscale VPN's toggle is off. This is because GuiMenu::openNetworkSettings(bool selectWifiEnable, bool selectAdhocEnable) does not persist the tailscale.up state that the user selected.

This PR fixes that issue, and Tailscale VPN status is now remembered between restarts and exiting the Network Settings menu, just like ZeroTier.

This was built and tested, verified working on my AYN Thor (SM8550).