### PR TITLE
screensaver: add screen_off mode that actually powers down the panel and LEDs

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1402,6 +1402,95 @@ void ApiSystem::setBrightness(BrightnessDevice bd)
 	Utils::FileSystem::writeAllText(bd.path, content);
 }
 
+static int sSavedBrightnessRaw = -1;
+
+bool ApiSystem::isDisplayPowerControlSupported()
+{
+#if WIN32
+	return true;
+#else
+	std::vector<BrightnessDevice> devices;
+	return getBrightness(devices) && !devices.empty();
+#endif
+}
+
+bool ApiSystem::setDisplayPower(bool on)
+{
+#if WIN32
+	HWND hwnd = GetDesktopWindow();
+	if (hwnd == nullptr)
+		return false;
+
+		SendMessageW(hwnd, WM_SYSCOMMAND, SC_MONITORPOWER, on ? (LPARAM)-1 : (LPARAM)2);
+	return true;
+#else
+	std::vector<BrightnessDevice> devices;
+	if (!getBrightness(devices) || devices.empty())
+		return false;
+
+	const BrightnessDevice& bd = devices[0];
+
+	std::string blPowerPath = Utils::FileSystem::getParent(bd.path) + "/bl_power";
+	if (Utils::FileSystem::exists(blPowerPath))
+	{
+		Utils::FileSystem::writeAllText(blPowerPath, on ? "0\n" : "4\n");
+		return true;
+	}
+
+	if (!on)
+	{
+		sSavedBrightnessRaw = Utils::String::toInteger(Utils::FileSystem::readAllText(bd.path));
+		Utils::FileSystem::writeAllText(bd.path, "0\n");
+	}
+	else
+	{
+		int restore = sSavedBrightnessRaw > 0 ? sSavedBrightnessRaw : 1;
+		Utils::FileSystem::writeAllText(bd.path, std::to_string(restore) + "\n");
+	}
+	return true;
+#endif
+}
+
+static int sSavedLEDBrightness = -1;
+
+bool ApiSystem::isLEDControlSupported()
+{
+#if WIN32
+	return false;
+#else
+	int dummy = 0;
+	return getLEDBrightness(dummy);
+#endif
+}
+
+bool ApiSystem::turnLEDsOff()
+{
+#if WIN32
+	return false;
+#else
+	int current = 0;
+	if (!getLEDBrightness(current))
+		return false;
+	sSavedLEDBrightness = current;
+	executeScript("batocera-led-handheld block_color_changes");
+	setLEDBrightness(0);
+	return true;
+#endif
+}
+
+bool ApiSystem::restoreLEDs()
+{
+#if WIN32
+	return false;
+#else
+	if (sSavedLEDBrightness < 0)
+		return false;
+	setLEDBrightness(sSavedLEDBrightness);
+	sSavedLEDBrightness = -1;
+	return true;
+#endif
+}
+
 static std::string LED_COLOUR_NAME;
 static std::string LED_BRIGHTNESS_VALUE;
 static std::string LED_MAX_BRIGHTNESS_VALUE;
@@ -1551,12 +1640,16 @@ bool ApiSystem::getLEDBrightness(int& value)
     if (LED_BRIGHTNESS_VALUE.empty() || LED_MAX_BRIGHTNESS_VALUE.empty())
     {
         auto directories = Utils::FileSystem::getDirContent("/sys/class/leds");
+        // sort so the resolved LED is deterministic across boots
+        directories.sort();
 
         for (const auto& directory : directories)
         {
-            if (directory.find("multicolor") != std::string::npos || 
+            if (directory.find("multicolor") != std::string::npos ||
                 directory.find(":rgb:joystick_rings") != std::string::npos ||
-                directory.find("l:r1") != std::string::npos) 
+                directory.find("l:r1") != std::string::npos ||
+                directory.find("rgb:l") != std::string::npos ||
+                directory.find("rgb:r") != std::string::npos)
             {
                 std::string ledBrightnessPath = directory + "/brightness";
                 std::string ledMaxBrightnessPath = directory + "/max_brightness";
@@ -1659,12 +1752,29 @@ void ApiSystem::setLEDBrightness(int value)
             }
         }
     }
-    else 
+    else
     {
-        // Fallback for standard devices (multicolor/joystick_rings handles scaling internally)
-        int max = Utils::String::toInteger(Utils::FileSystem::readAllText(LED_MAX_BRIGHTNESS_VALUE));
-        int brightnessValue = static_cast<int>(factor * max + 0.5f);
-        Utils::FileSystem::writeAllText(LED_BRIGHTNESS_VALUE, std::to_string(brightnessValue) + "\n");
+        // Unified path. Enumerate every matching LED so multi-LED arrays dim together.
+        auto directories = Utils::FileSystem::getDirContent("/sys/class/leds");
+        for (const auto& directory : directories)
+        {
+            if (directory.find("multicolor") == std::string::npos &&
+                directory.find(":rgb:joystick_rings") == std::string::npos &&
+                directory.find("l:r1") == std::string::npos &&
+                directory.find("rgb:l") == std::string::npos &&
+                directory.find("rgb:r") == std::string::npos)
+                continue;
+
+            std::string bpath = directory + "/brightness";
+            std::string mpath = directory + "/max_brightness";
+            if (!Utils::FileSystem::exists(bpath) || !Utils::FileSystem::exists(mpath))
+                continue;
+
+            int dmax = Utils::String::toInteger(Utils::FileSystem::readAllText(mpath));
+            if (dmax <= 0) continue;
+            int dvalue = static_cast<int>(factor * dmax + 0.5f);
+            Utils::FileSystem::writeAllText(bpath, std::to_string(dvalue) + "\n");
+        }
     }
 }
 

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -337,6 +337,13 @@ public:
 	bool	getBrightness(std::vector<BrightnessDevice>& value);
 	void	setBrightness(BrightnessDevice value);
 
+	bool	setDisplayPower(bool on);
+	bool	isDisplayPowerControlSupported();
+
+	bool	turnLEDsOff();
+	bool	restoreLEDs();
+	bool	isLEDControlSupported();
+
 	// LED RGB sliders
 	bool getLED(int& red, int& green, int& blue);
 	void getLEDColours(int& red, int& green, int& blue);

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -41,7 +41,8 @@ SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mSystemName(""),
 	mGameName(""),
 	mCurrentGame(NULL),
-	mLoadingNext(false)
+	mLoadingNext(false),
+	mDisplayPoweredOff(false)
 {
 
 	mWindow->setScreenSaver(this);
@@ -95,7 +96,23 @@ void SystemScreenSaver::startScreenSaver()
 			screensaver_behavior = "black";
 	}
 
-	if (!loadingNext && Settings::getInstance()->getBool("StopMusicOnScreenSaver")) //(Settings::getInstance()->getBool("VideoAudio") && !Settings::getInstance()->getBool("ScreenSaverVideoMute")))
+	if (screensaver_behavior == "screen_off")
+	{
+		if (ApiSystem::getInstance()->setDisplayPower(false))
+		{
+			mDisplayPoweredOff = true;
+			ApiSystem::getInstance()->turnLEDsOff();
+			mState = STATE_SCREENSAVER_ACTIVE;
+			mCurrentGame = NULL;
+			PowerSaver::runningScreenSaver(true);
+			return;
+		}
+
+		LOG(LogWarning) << "ScreenSaver: screen_off not supported on this platform, falling back to black";
+		screensaver_behavior = "black";
+	}
+
+	if (!loadingNext && Settings::getInstance()->getBool("StopMusicOnScreenSaver")) //(Settings::getInstance()->getBool("VideoAudio") && !Settings::getInstance()->getBool("ScreenSaverVideoMute"))
 		AudioManager::getInstance()->deinit();
 
 
@@ -206,6 +223,14 @@ void SystemScreenSaver::stopScreenSaver()
 {
 	bool isExitingScreenSaver = !mLoadingNext;
 	bool isVideoScreenSaver = (mVideoScreensaver != nullptr);
+
+	// Restore panel + LEDs before anything else so the wake transition is immediate.
+	if (mDisplayPoweredOff)
+	{
+		ApiSystem::getInstance()->setDisplayPower(true);
+		ApiSystem::getInstance()->restoreLEDs();
+		mDisplayPoweredOff = false;
+	}
 
 	if (mLoadingNext)
 		mFadingImageScreensaver = mImageScreensaver;

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -128,6 +128,7 @@ private:
 	int 			mVideoChangeTime;
 	bool			mLoadingNext;
 
+	bool			mDisplayPoweredOff;
 };
 
 #endif // ES_APP_SYSTEM_SCREEN_SAVER_H

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -13,6 +13,7 @@
 
 #define fake_gettext_dim			_("dim")
 #define fake_gettext_black			_("black")
+#define fake_gettext_screen_off		_("screen off")
 #define fake_gettext_randomvideo	_("random video")
 #define fake_gettext_slideshow		_("slideshow")
 #define fake_gettext_suspend		_("suspend")
@@ -44,10 +45,15 @@ GuiGeneralScreensaverOptions::GuiGeneralScreensaverOptions(Window* window, int s
 	// Screensaver behavior
 	auto ctlBehavior = std::make_shared< OptionListComponent<std::string> >(mWindow, _("SCREENSAVER TYPE"), false);
 
+	std::vector<std::string> ssOptions = { "dim", "black" };
+	if (ApiSystem::getInstance()->isDisplayPowerControlSupported())
+		ssOptions.push_back("screen_off");
+	ssOptions.push_back("random video");
+	ssOptions.push_back("slideshow");
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::SUSPEND))
-		ctlBehavior->addRange({ "dim", "black", "random video", "slideshow", "suspend" }, ssBehavior);
-	else
-		ctlBehavior->addRange({ "dim", "black", "random video", "slideshow" }, ssBehavior);
+		ssOptions.push_back("suspend");
+
+	ctlBehavior->addRange(ssOptions, ssBehavior);
 
 	addWithLabel(_("SCREENSAVER TYPE"), ctlBehavior, selectItem == 1);
 	ctlBehavior->setSelectedChangedCallback([this](const std::string& name)

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -310,6 +310,9 @@ bool loadSystemConfigFile(Window* window, const char** errorString)
 //called on exit, assuming we get far enough to have the log initialized
 void onExit()
 {
+	ApiSystem::getInstance()->setDisplayPower(true);
+	ApiSystem::getInstance()->restoreLEDs();
+
 	Log::close();
 }
 
@@ -348,7 +351,11 @@ void signalHandler(int signum)
 
 	Log::flush();
 
-	// cleanup and close up stuff here  
+	// undo any screen_off state so a crash doesn't leave the panel dark
+	ApiSystem::getInstance()->setDisplayPower(true);
+	ApiSystem::getInstance()->restoreLEDs();
+
+	// cleanup and close up stuff here
 	exit(signum);
 }
 


### PR DESCRIPTION


The existing "black" and "dim" screensaver modes paint a colored overlay each frame while the backlight stays fully on and any controllable LEDs continue to draw their configured color.