### PR TITLE
wifi: quote SSID and passphrase passed to wifictl

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -445,19 +445,19 @@ bool ApiSystem::enableWifi(std::string ssid, std::string key, std::string countr
 	if (!ret)
 		return ret;
 	
-	return executeScript("wifictl connect \"" + ssid + "\" \"" + key + "\" \"" + country + "\"");
+	// executeScript() runs the command through a shell, so the SSID and the
+	// passphrase have to be quoted as literals. Double quotes are not enough:
+	// they still let the shell expand $, ` and \, which silently corrupts any
+	// passphrase containing them (and lets a crafted SSID run commands).
+	return executeScript("wifictl connect " + Utils::String::shellQuote(ssid) +
+			     " " + Utils::String::shellQuote(key) +
+			     " " + Utils::String::shellQuote(country));
 }
 #else
-bool ApiSystem::enableWifi(std::string ssid, std::string key) 
+bool ApiSystem::enableWifi(std::string ssid, std::string key)
 {
-	// Escape single quote if it's in the passphrase
-	using std::regex;
-	using std::regex_replace;
-
-	regex tic("(')");
-	key = regex_replace(key,tic,"\\'");
-	ssid = regex_replace(ssid,tic,"\\'");
-	return executeScript("wifictl enable $\'" + ssid + "\' $\'" + key + "\'");
+	return executeScript("wifictl enable " + Utils::String::shellQuote(ssid) +
+			     " " + Utils::String::shellQuote(key));
 }
 #endif
 

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -423,6 +423,26 @@ namespace Utils
 
 		} // trim
 
+		std::string shellQuote(const std::string& _string)
+		{
+			// Wrap the value in single quotes so it reaches the command as one
+			// literal argument. Inside single quotes the shell expands nothing,
+			// so $, `, \, " and whitespace survive untouched; a single quote
+			// itself has to leave the quoted run, be escaped, and re-enter it.
+			std::string quoted = "'";
+
+			for (auto character : _string)
+			{
+				if (character == '\'')
+					quoted += "'\\''";
+				else
+					quoted += character;
+			}
+
+			return quoted + "'";
+
+		} // shellQuote
+
 		std::string replace(const std::string& _string, const std::string& _replace, const std::string& _with)
 		{
 			if (_replace.empty())

--- a/es-core/src/utils/StringUtil.h
+++ b/es-core/src/utils/StringUtil.h
@@ -20,6 +20,7 @@ namespace Utils
 		std::string  toLower            (const std::string& _string);
 		std::string  toUpper            (const std::string& _string);
 		std::string  trim               (const std::string& _string);
+		std::string  shellQuote         (const std::string& _string);
 		std::string  replace            (const std::string& _string, const std::string& _replace, const std::string& _with);
 		bool         startsWith         (const std::string& _string, const std::string& _start);
 		bool         endsWith           (const std::string& _string, const std::string& _end);


### PR DESCRIPTION
special characters (like $ ) in a wifi password would make connection attempts fail with "WIFI CONFIGURATION ERROR". this patch just escapes special characters.

tested on my konkr pocket fite elite with a wifi network that has a dollar sign in its password.