### PR TITLE
menu: add SING-BOX VPN toggle to VPN SERVICES

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5584,6 +5584,21 @@ void GuiMenu::openNetworkSettings(bool selectWifiEnable, bool selectAdhocEnable)
 		SystemConf::getInstance()->set("zerotier.up", ztEnabled ? "1" : "0");
 	});
 
+	const std::string singboxConfigFile = "/storage/.config/sing-box/config.json";
+	if (Utils::FileSystem::exists(singboxConfigFile)) {
+		auto singbox = std::make_shared<SwitchComponent>(mWindow);
+		bool sbUp = SystemConf::getInstance()->get("singbox.up") == "1";
+		singbox->setState(sbUp);
+		s->addWithDescription(_("VLESS/REALITY, AMNEZIAWG (SING-BOX)"), _("Obfuscated proxy - also WireGuard, Shadowsocks, Hysteria2, TUIC, VMess. TUN transparent routing."), singbox);
+		singbox->setOnChangedCallback([singbox] {
+			if (singbox->getState())
+				Utils::Platform::runSystemCommand("systemctl start sing-box", "", nullptr);
+			else
+				Utils::Platform::runSystemCommand("systemctl stop sing-box", "", nullptr);
+			SystemConf::getInstance()->set("singbox.up", singbox->getState() ? "1" : "0");
+		});
+	}
+
 	mWindow->pushGui(s);
 }
 


### PR DESCRIPTION
## What
Adds a `VLESS/REALITY, AMNEZIAWG (SING-BOX)` switch to the VPN SERVICES group in Network Settings, next to WireGuard / Tailscale / ZeroTier.

It mirrors the existing WireGuard entry: shown only when a config exists at `/storage/.config/sing-box/config.json`, toggling `systemctl start/stop sing-box` and persisting the `singbox.up` setting. A short description lists the supported protocols so users recognise their own.

## Depends on
The sing-box service package: https://github.com/ROCKNIX/distribution/pull/3111. The toggle degrades cleanly without it (hidden unless a sing-box config is present).

## Testing
Compiled clean as part of a full SM8750 image build (ES + the package). The action behind the switch (`systemctl start/stop sing-box`, `singbox.up`) was verified live on a KONKR Pocket FIT Elite: setting `singbox.up=1` with a config brings up the tunnel and the external IP resolves to the VPN exit.
